### PR TITLE
load from arbitrary readers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,10 +104,22 @@ impl PdfObjectDeref for Object {
 }
 
 impl Form {
+
+    /// Takes a reader containing a PDF with a fillable form, analyzes the content, and attempts to
+    /// identify all of the fields the form has. This is the only way to create a `Form`
+    pub fn load_from<R: io::Read>(reader: R) -> Result<Self, LoadError> {
+        let doc = Document::load_from(reader)?;
+        Self::load_doc(doc)
+    }
+
     /// Takes a path to a PDF with a fillable form, analyzes the file, and attempts to identify all
     /// of the fields the form has. This is the only way to create a `Form`
     pub fn load<P: AsRef<Path>>(path: P) -> Result<Self, LoadError> {
         let doc = Document::load(path)?;
+        Self::load_doc(doc)
+    }
+
+    fn load_doc(doc: Document) -> Result<Self, LoadError>{
         let mut form_ids = Vec::new();
         let mut queue = VecDeque::new();
         // Block so borrow of doc ends before doc is moved into the result

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,14 +106,14 @@ impl PdfObjectDeref for Object {
 impl Form {
 
     /// Takes a reader containing a PDF with a fillable form, analyzes the content, and attempts to
-    /// identify all of the fields the form has. This is the only way to create a `Form`
+    /// identify all of the fields the form has.
     pub fn load_from<R: io::Read>(reader: R) -> Result<Self, LoadError> {
         let doc = Document::load_from(reader)?;
         Self::load_doc(doc)
     }
 
     /// Takes a path to a PDF with a fillable form, analyzes the file, and attempts to identify all
-    /// of the fields the form has. This is the only way to create a `Form`
+    /// of the fields the form has.
     pub fn load<P: AsRef<Path>>(path: P) -> Result<Self, LoadError> {
         let doc = Document::load(path)?;
         Self::load_doc(doc)


### PR DESCRIPTION
I want to use your crate with a PDF which I hardcoded using `include_bytes!` into my application. The extra constructor would help me to avoid creating a file during execution.