### PR TITLE
Cargo.toml: Update 'lopdf' to v0.27

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ edition = "2018"
 [dependencies]
 bitflags = "^1.2"
 derive-error = "^0.0.4"
-lopdf = "^0.25"
+lopdf = "^0.27"


### PR DESCRIPTION
I was getting this error when attempting to load a PDF with
`Form::load("form.pdf")`:

    panicked at 'attempted to leave type
    `linked_hash_map::Node<alloc::vec::Vec<u8>, object::Object>`
    uninitialized, which is invalid',
    $HOME/.cargo/registry/src/github.com-1ecc6299db9ec823/linked-hash-map-0.4.2/src/lib.rs:174:52

Updating 'lopdf' fixes the problem.