### PR TITLE
Switch from 'derive-error' to 'thiserror'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,5 @@ edition = "2018"
 
 [dependencies]
 bitflags = "^1.2"
-derive-error = "^0.0.4"
 lopdf = "^0.25"
+thiserror = "1.0.31"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,5 @@
 #[macro_use]
 extern crate bitflags;
-#[macro_use]
-extern crate derive_error;
 
 mod utils;
 
@@ -40,28 +38,34 @@ pub enum FieldType {
     Unknown,
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug, thiserror::Error)]
 /// Errors that may occur while loading a PDF
 pub enum LoadError {
     /// An Lopdf Error
-    LopdfError(lopdf::Error),
+    #[error("Lopdf error")]
+    LopdfError(#[from] lopdf::Error),
     /// The reference `ObjectId` did not point to any values
-    #[error(non_std, no_from)]
+    #[error("The reference `{0:?}` did not point to any values")]
     NoSuchReference(ObjectId),
     /// An element that was expected to be a reference was not a reference
+    #[error("An element that was expected to be a reference was not a reference")]
     NotAReference,
 }
 
 /// Errors That may occur while setting values in a form
-#[derive(Debug, Error)]
+#[derive(Debug, thiserror::Error)]
 pub enum ValueError {
     /// The method used to set the state is incompatible with the type of the field
+    #[error("The method used to set the state is incompatible with the type of the field")]
     TypeMismatch,
     /// One or more selected values are not valid choices
+    #[error("One or more selected values are not valid choices")]
     InvalidSelection,
     /// Multiple values were selected when only one was allowed
+    #[error("Multiple values were selected when only one was allowed")]
     TooManySelected,
     /// Readonly field cannot be edited
+    #[error("Readonly field cannot be edited")]
     Readonly,
 }
 /// The current state of a form field


### PR DESCRIPTION
With 'thiserror', we can include the source error text in the error
message, making it easier to identify the cause of the error.

I mostly duplicated the doc comments in the error messages to mimic the
behaviour of 'derive-error'.